### PR TITLE
Make `optimizer` a lazy property

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -78,6 +78,24 @@ def test_bayesian_optimizer(database, monkeypatch):
 
 
 @pytest.mark.usefixtures("clean_db")
+def test_int(database, monkeypatch):
+    """Check support of integer values."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(["hunt", "--config",
+                         "./orion_config_bayes.yaml", "./rosenbrock.py",
+                         "-x~uniform(-5, 5, discrete=True)"])
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_categorical(database, monkeypatch):
+    """Check support of categorical values."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(["hunt", "--config",
+                         "./orion_config_bayes.yaml", "./rosenbrock.py",
+                         "-x~choices([-5, -2, 0, 2, 5])"])
+
+
+@pytest.mark.usefixtures("clean_db")
 def test_bayesian_optimizer_two_inputs(database, monkeypatch):
     """Check functionality of BayesianOptimizer wrapper for 2 dimensions."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/orion_config_bayes.yaml
+++ b/tests/orion_config_bayes.yaml
@@ -5,7 +5,7 @@ max_trials: 5
 
 algorithms:
   BayesianOptimizer:
-    seed: 1
+    seed: 2
     n_initial_points: 10
     acq_func: gp_hedge
     alpha: 1.0e-10


### PR DESCRIPTION
Why:

The transformed space is only available after the optimizer is fully
initialized. For this reason, we cannot build the optimizer inside
`init`.

Note:

`seed_rng` is called at the end of `init`. Since the optimizer cannot be
built at this time, we make the seeding lazy as well and delay its
application to right after the optimizer's creation.