### PR TITLE
Adjust to new test suite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ orion.algo.skopt
     :target: https://codecov.io/gh/Epistimio/orion.algo.skopt
     :alt: Codecov Report
 
-.. |travis| image:: https://travis-ci.org/Epistimio/orion.algo.skopt.svg?branch=master
-    :target: https://travis-ci.org/Epistimio/orion.algo.skopt
-    :alt: Travis tests
+.. |github-actions| image:: https://github.com/Epistimio/orion.algo.skopt/workflows/build/badge.svg?branch=master&event=pull_request
+    :target: https://github.com/Epistimio/orion.algo.skopt/actions?query=workflow:build+branch:master+event:schedule
+    :alt: Github actions tests
 
 
 This package is a plugin for `Oríon`_, providing a wrapper for `skopt`_ optimizers.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup_args = dict(
             "skopt_bayes = orion.algo.skopt.bayes:BayesianOptimizer"
         ],
     },
-    install_requires=["orion>=0.1.11", "scikit-optimize>=0.5.1"],
+    install_requires=["orion>=0.1.15", "scikit-optimize>=0.5.1"],
     tests_require=tests_require,
     setup_requires=["setuptools", "pytest-runner>=2.0,<3dev"],
     extras_require=dict(test=tests_require),

--- a/src/orion/algo/skopt/bayes.py
+++ b/src/orion/algo/skopt/bayes.py
@@ -220,8 +220,8 @@ class BayesianOptimizer(BaseAlgorithm):
         Perform a step towards negative gradient and suggest that point.
 
         """
-        if num is None:
-            num = max(self.n_initial_points - self.n_observed, 1)
+        num = min(num, max(self.n_initial_points - self.n_suggested, 1))
+
         samples = []
         candidates = []
         while len(samples) < num:

--- a/src/orion/algo/skopt/bayes.py
+++ b/src/orion/algo/skopt/bayes.py
@@ -268,15 +268,17 @@ class BayesianOptimizer(BaseAlgorithm):
         return self._suggest(num, sample)
 
     def _suggest_bo(self, num):
+        # pylint: disable = unused-argument
         def suggest_bo(num):
-            point = self.optimizer._ask()  # pylint: disable = protected-access
+            # pylint: disable = protected-access
+            point = self.optimizer._ask()
 
             # If already suggested, give corresponding result to BO to sample another point
             if self.has_suggested(point):
                 result = self._trials_info[self.get_id(point)][1]
                 if result is None:
                     results = []
-                    for other_point, other_result in self._trials_info.values():
+                    for _, other_result in self._trials_info.values():
                         if other_result is not None:
                             results.append(other_result["objective"])
                     result = numpy.array(results).mean()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform integration tests for `orion.algo.skopt`."""
+import itertools
 import os
 
 import numpy
@@ -10,299 +11,60 @@ from orion.algo.space import Integer, Real, Space
 from orion.client import create_experiment
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.testing import OrionState
+from orion.testing.algo import BaseAlgoTests
 
 
-@pytest.fixture()
-def space():
-    """Return an optimization space"""
-    space = Space()
-    dim1 = Integer("yolo1", "uniform", -3, 6)
-    space.register(dim1)
-    dim2 = Real("yolo2", "uniform", 0, 1)
-    space.register(dim2)
-
-    return space
+N_INIT = 10
 
 
-@pytest.fixture()
-def real_space():
-    """Return a real optimization space"""
-    space = Space()
-    dim1 = Real("yolo1", "uniform", -3, 6)
-    space.register(dim1)
-    dim2 = Real("yolo2", "uniform", 0, 1)
-    space.register(dim2)
+class TestBOSkopt(BaseAlgoTests):
 
-    return space
+    algo_name = "bayesianoptimizer"
+    config = {
+        "n_initial_points": N_INIT,
+        "normalize_y": True,
+        "acq_func": "EI",
+        "alpha": 1e-8,
+        "n_restarts_optimizer": 0,
+        "noise": False,
+        "strategy": None,
+        "seed": 1234,  # Because this is so random
+    }
 
+    def test_suggest(self, mocker, num, attr):
+        algo = self.create_algo()
+        spy = self.spy_phase(mocker, num, algo, attr)
+        points = algo.suggest()
+        if num == 0:
+            assert len(points) == N_INIT
+        else:
+            assert len(points) == 1
 
-def test_seeding(space):
-    """Verify that seeding makes sampling deterministic"""
-    bayesian_optimizer = PrimaryAlgo(
-        space, {"bayesianoptimizer": {"n_initial_points": 3}}
-    )
-
-    bayesian_optimizer.seed_rng(1)
-    a = bayesian_optimizer.suggest(1)[0]
-    with pytest.raises(AssertionError):
-        numpy.testing.assert_equal(a, bayesian_optimizer.suggest(1)[0])
-
-    bayesian_optimizer.seed_rng(1)
-    numpy.testing.assert_equal(a, bayesian_optimizer.suggest(1)[0])
-
-
-def test_seeding_bo(space):
-    """Verify that seeding makes bayesian optimization deterministic"""
-    bayesian_optimizer = PrimaryAlgo(
-        space, {"bayesianoptimizer": {"n_initial_points": 3}}
-    )
-
-    bayesian_optimizer.seed_rng(1)
-    for i in range(5):
-        a = bayesian_optimizer.suggest(1)[0]
-        bayesian_optimizer.observe([a], [{"objective": i}])
-    with pytest.raises(AssertionError):
-        numpy.testing.assert_equal(a, bayesian_optimizer.suggest(1)[0])
-
-    # Same seed, should be equal
-    bayesian_optimizer = PrimaryAlgo(
-        space, {"bayesianoptimizer": {"n_initial_points": 3}}
-    )
-    bayesian_optimizer.seed_rng(1)
-    for i in range(5):
-        b = bayesian_optimizer.suggest(1)[0]
-        bayesian_optimizer.observe([b], [{"objective": i}])
-    numpy.testing.assert_equal(a, b)
-
-    # Not same seed, should diverge
-    bayesian_optimizer = PrimaryAlgo(
-        space, {"bayesianoptimizer": {"n_initial_points": 3}}
-    )
-    bayesian_optimizer.seed_rng(2)
-    for i in range(5):
-        c = bayesian_optimizer.suggest(1)[0]
-        bayesian_optimizer.observe([c], [{"objective": i}])
-    with pytest.raises(AssertionError):
-        numpy.testing.assert_equal(a, c)
-
-
-def test_set_state(space):
-    """Verify that resetting state makes sampling deterministic"""
-    bayesian_optimizer = PrimaryAlgo(space, "bayesianoptimizer")
-
-    state = bayesian_optimizer.state_dict
-    a = bayesian_optimizer.suggest(1)[0]
-    with pytest.raises(AssertionError):
-        numpy.testing.assert_equal(a, bayesian_optimizer.suggest(1)[0])
-
-    bayesian_optimizer.set_state(state)
-    numpy.testing.assert_equal(a, bayesian_optimizer.suggest(1)[0])
-
-
-def test_set_state_bo(real_space):
-    """Verify that resetting state during BO makes sampling deterministic"""
-    n_init = 3
-    optimizer = PrimaryAlgo(
-        real_space,
-        {
-            "bayesianoptimizer": {
-                "n_initial_points": 3,
-                "normalize_y": True,
-                "acq_func": "EI",
-                "noise": None,
+    def test_is_done_cardinality(self):
+        # TODO: Support correctly loguniform(discrete=True)
+        #       See https://github.com/Epistimio/orion/issues/566
+        space = self.update_space(
+            {
+                "x": "uniform(0, 4, discrete=True)",
+                "y": "choices(['a', 'b', 'c'])",
+                "z": "uniform(1, 6, discrete=True)",
             }
-        },
-    )
-
-    for i in range(n_init + 2):
-        a = optimizer.suggest(1)[0]
-        if i < n_init:
-            assert getattr(optimizer.algorithm.optimizer, "_next_x", None) is None
-        optimizer.observe([a], [{"objective": i / (n_init + 2)}])
-
-    # Make sure we left random regime and are now doing sampling
-    assert optimizer.algorithm.optimizer._next_x is not None
-    assert optimizer.algorithm.optimizer._n_initial_points <= 0
-
-    # Make sure BO returns different samples during iterations
-    state = optimizer.state_dict
-    a = optimizer.suggest(1)[0]
-    optimizer.observe([a], [{"objective": i + 1 / (n_init + 3)}])
-
-    with pytest.raises(AssertionError):
-        numpy.testing.assert_equal(a, optimizer.suggest(1)[0])
-
-    # Reset state and make sure BO returns the same sample
-    optimizer.set_state(state)
-
-    assert optimizer.algorithm.optimizer._next_x is not None
-    assert optimizer.algorithm.optimizer._n_initial_points <= 0
-
-    numpy.testing.assert_equal(a, optimizer.suggest(1)[0])
-
-    # Test also when setting state to new optimizer, not old version.
-    new_optimizer = PrimaryAlgo(
-        real_space,
-        {
-            "bayesianoptimizer": {
-                "n_initial_points": 3,
-                "normalize_y": True,
-                "acq_func": "EI",
-                "noise": None,
-            }
-        },
-    )
-
-    new_optimizer.set_state(state)
-
-    assert new_optimizer.algorithm.optimizer._next_x is not None
-    assert new_optimizer.algorithm.optimizer._n_initial_points <= 0
-
-    numpy.testing.assert_equal(a, new_optimizer.suggest(1)[0])
-
-
-def test_bayesian_optimizer_basic(monkeypatch):
-    """Check functionality of BayesianOptimizer wrapper for single shaped dimension."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~uniform(-5, 5)",
-            ]
         )
+        space = self.create_space(space)
+        assert space.cardinality == 5 * 3 * 6
+
+        algo = self.create_algo(space=space)
+        for i, (x, y, z) in enumerate(itertools.product(range(5), "abc", range(1, 7))):
+            assert not algo.is_done
+            n = len(algo.algorithm._trials_info)
+            algo.observe([[x, y, z]], [dict(objective=i)])
+            assert len(algo.algorithm._trials_info) == n + 1
+
+        assert i + 1 == space.cardinality
+
+        assert algo.is_done
 
 
-def test_int(monkeypatch):
-    """Check support of integer values."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--name",
-                "exp",
-                "--max-trials",
-                "5",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~uniform(-5, 5, discrete=True)",
-            ]
-        )
-
-
-def test_categorical(monkeypatch):
-    """Check support of categorical values."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--name",
-                "exp",
-                "--max-trials",
-                "5",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~choices([-5, -2, 0, 2, 5])",
-            ]
-        )
-
-
-def test_linear(monkeypatch):
-    """Check support of logarithmic distributions."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--name",
-                "exp",
-                "--max-trials",
-                "5",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~loguniform(1, 50, discrete=True)",
-            ]
-        )
-
-
-def test_shape(monkeypatch):
-    """Check support of multidim values."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--name",
-                "exp",
-                "--max-trials",
-                "5",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~uniform(-5, 5, shape=3)",
-            ]
-        )
-
-
-def test_bayesian_optimizer_two_inputs(monkeypatch):
-    """Check functionality of BayesianOptimizer wrapper for 2 dimensions."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./rosenbrock.py",
-                "-x~uniform(-5, 5)",
-                "-y~uniform(-10, 10)",
-            ]
-        )
-
-
-def test_bayesian_optimizer_actually_optimize(monkeypatch):
-    """Check if Bayesian Optimizer has better optimization than random search."""
-    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    best_random_search = 23.403275057472825
-
-    with OrionState(experiments=[], trials=[]):
-
-        orion.core.cli.main(
-            [
-                "hunt",
-                "--name",
-                "exp",
-                "--max-trials",
-                "20",
-                "--config",
-                "./orion_config_bayes.yaml",
-                "./black_box.py",
-                "-x~uniform(-50, 50, precision=10)",
-            ]
-        )
-
-        exp = create_experiment(name="exp")
-
-        objective = exp.stats["best_evaluation"]
-
-        assert best_random_search > objective
+TestBOSkopt.set_phases(
+    [("random", 0, "space.sample"), ("bo", N_INIT + 1, "optimizer._ask")]
+)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -9,7 +9,6 @@ import orion.core.cli
 import pytest
 from orion.testing.algo import BaseAlgoTests
 
-
 N_INIT = 10
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-pytest >= 3.0.0
+pytest >= 3.6.0
 pytest-xdist
 pytest-timeout
+pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ commands =
 
 [testenv:packaging]
 description = Check whether README.rst is reST and missing from MANIFEST.in
-basepython = python3.6
+basepython = python3
 deps =
     check-manifest
     readme_renderer


### PR DESCRIPTION
Why:

A new test suite for algorithms is available in orion.testing making it
easier to test all algorithms on the same grounds.

Note:

A few changes were needed to comply with the new tests suite.

- The random phase is implemented using Orion's space sampling instead
of relying on skopts samplers. This is to comply with transformed space,
particularly with cardinality. This is a drawback because we loose
access to various samplers in skopt, but there samplers where not
accessing with currently options of the wrapper.
- The method is_done is reimplemented to take account of original space
(not transformed one) cardinality.