### PR TITLE
Add documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toxenv: [black, isort, pylint]
+        toxenv: [black, isort, pylint, doc8, docs]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Setup MongoDB
-      uses: supercharge/mongodb-github-action@1.3.0
-      with:
-          mongodb-version: 4.2
-    - name: Configure MongoDB
-      run: mongo orion_test --eval 'db.createUser({user:"user",pwd:"pass",roles:["readWrite"]});'
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,7 +14,7 @@ exclude .mailmap
 
 # Include src, tests, docs
 recursive-include docs *.rst *.py *.gitkeep
-include docs/requirements.txt
+include docs/test.sh
 prune docs/build
 prune docs/src/reference
 recursive-include src *.py

--- a/docs/doc.rst
+++ b/docs/doc.rst
@@ -1,0 +1,83 @@
+.. _scikit-bayesopt:
+
+Scikit Bayesian Optimizer
+-------------------------
+
+``orion.algo.skopt`` provides a wrapper for `Bayesian optimizer`_ using Gaussian process implemented
+in `scikit optimize`_.
+
+.. _scikit optimize: https://scikit-optimize.github.io/
+.. _bayesian optimizer: https://scikit-optimize.github.io/#skopt.Optimizer
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: sh
+
+   pip install orion.algo.skopt
+
+Configuration
+~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    experiment:
+        algorithms:
+            BayesianOptimizer:
+                seed: null
+                n_initial_points: 10
+                acq_func: gp_hedge
+                alpha: 1.0e-10
+                n_restarts_optimizer: 0
+                noise: "gaussian"
+                normalize_y: False
+
+``seed``
+
+``n_initial_points``
+
+Number of evaluations of ``func`` with initialization points
+before approximating it with ``base_estimator``. Points provided as
+``x0`` count as initialization points. If len(x0) < n_initial_points
+additional points are sampled at random.
+
+``acq_func``
+
+Function to minimize over the posterior distribution. Can be:
+``["LCB", "EI", "PI", "gp_hedge", "EIps", "PIps"]``. Check skopt
+docs for details.
+
+``alpha``
+
+Value added to the diagonal of the kernel matrix during fitting.
+Larger values correspond to increased noise level in the observations
+and reduce potential numerical issues during fitting. If an array is
+passed, it must have the same number of entries as the data used for
+fitting and is used as datapoint-dependent noise level. Note that this
+is equivalent to adding a WhiteKernel with c=alpha. Allowing to specify
+the noise level directly as a parameter is mainly for convenience and
+for consistency with Ridge.
+
+``n_restarts_optimizer``
+
+The number of restarts of the optimizer for finding the kernel's
+parameters which maximize the log-marginal likelihood. The first run
+of the optimizer is performed from the kernel's initial parameters,
+the remaining ones (if any) from thetas sampled log-uniform randomly
+from the space of allowed theta-values. If greater than 0, all bounds
+must be finite. Note that n_restarts_optimizer == 0 implies that one
+run is performed.
+
+``noise``
+
+If set to "gaussian", then it is assumed that y is a noisy estimate of f(x) where the
+noise is gaussian.
+
+``normalize_y``
+
+Whether the target values y are normalized, i.e., the mean of the
+observed target values become zero. This parameter should be set to
+True if the target values' mean is expected to differ considerable from
+zero. When enabled, the normalization effectively modifies the GP's
+prior based on the data, which contradicts the likelihood principle;
+normalization is thus disabled per default.

--- a/docs/test.sh
+++ b/docs/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Fetch docs code
+git clone https://github.com/Epistimio/orion.git
+cd orion/
+git checkout master
+
+pip install -e .
+# Replace remote include by local include to test local doc version 
+sed -i 's/.. plugin-include:: https:\/\/raw.githubusercontent.com\/Epistimio\/orion.algo.skopt\/master/.. include:: ..\/..\/..\/../g' docs/src/user/algorithms.rst
+# Test
+tox -e docs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Common fixtures and utils for unittests and functional tests."""
+import pytest
+
+pytest.register_assert_rewrite("orion.testing")

--- a/tox.ini
+++ b/tox.ini
@@ -125,6 +125,21 @@ usedevelop = True
 commands =
     python setup.py test --addopts '-vvv --exitfirst --looponfail {posargs}'
 
+[testenv:doc8]
+description = Impose standards on *.rst documentation files
+basepython = python3
+skip_install = true
+deps =
+    doc8 == 0.8.*
+commands =
+    doc8 docs/
+
+[testenv:docs]
+description = Test integration of doc in main repo documentation
+basepython = python3
+commands =
+    bash docs/test.sh
+
 ## Release tooling (to be removed in favor of CI with CD)
 
 [testenv:build]
@@ -171,3 +186,8 @@ exclude_lines =
     pass
     raise AssertionError
     raise NotImplementedError
+
+# Doc8 configuration
+[doc8]
+max-line-length = 100
+file-encoding = utf-8


### PR DESCRIPTION
Documentation should be included in the plugin instead of in the core
repo. The local documentation in docs/doc.rst will be included in the
global doc using the custom sphinx extension plugin-include, which
will fetch the doc.rst from latest release of the plugin.

But doing so we need to make a special test in the plugin repo
by fetching the whole documentation and including the local version to
make sure we are not breaking the global documentation.