### PR TITLE
Adapt to orion v0.2.2

### DIFF
--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -21,6 +21,14 @@ using Gaussian process implemented in `scikit optimize`_.
                 n_restarts_optimizer: 0
                 noise: "gaussian"
                 normalize_y: False
+                parallel_strategy:
+                    of_type: StatusBasedParallelStrategy
+                    strategy_configs:
+                        broken:
+                            of_type: MaxParallelStrategy
+                    default_strategy:
+                        of_type: NoParallelStrategy
+
 
 .. autoclass:: orion.algo.skopt.bayes.BayesianOptimizer
    :exclude-members: space, state_dict, set_state, suggest, observe, is_done, seed_rng

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ setup_args = dict(
     package_dir={"": "src"},
     include_package_data=True,
     entry_points={
-        "OptimizationAlgorithm": [
-            "skopt_bayes = orion.algo.skopt.bayes:BayesianOptimizer"
-        ],
+        "BaseAlgorithm": ["skopt_bayes = orion.algo.skopt.bayes:BayesianOptimizer"],
     },
     install_requires=["orion>=0.1.15", "scikit-optimize>=0.5.1"],
     tests_require=tests_require,

--- a/src/orion/algo/skopt/bayes.py
+++ b/src/orion/algo/skopt/bayes.py
@@ -9,11 +9,16 @@
    :synopsis: Use Gaussian Process regression to locally search for a minimum.
 
 """
+from collections import defaultdict
+import copy
+import contextlib
 import logging
 
-import numpy
+import numpy as np
 from orion.algo.base import BaseAlgorithm
+from orion.algo.parallel_strategy import strategy_factory
 from orion.algo.space import check_random_state
+from orion.core.utils import format_trials
 from skopt import Optimizer, Space
 from skopt.learning import GaussianProcessRegressor
 from skopt.space import Real
@@ -46,10 +51,6 @@ class BayesianOptimizer(BaseAlgorithm):
        Problem's definition
     seed: int (default: None)
        Seed used for the random number generator
-    strategy : str (default: cl_min)
-       Method to use to sample multiple points.
-       Supported options are ``["cl_min", "cl_mean", "cl_max"]``.
-       Check skopt docs for details.
     n_initial_points : int (default: 10)
        Number of evaluations of trials with initialization points
        before approximating it with `base_estimator`. Points provided as
@@ -86,6 +87,13 @@ class BayesianOptimizer(BaseAlgorithm):
        zero. When enabled, the normalization effectively modifies the GP's
        prior based on the data, which contradicts the likelihood principle;
        normalization is thus disabled per default.
+    parallel_strategy: dict or None, optional
+        The configuration of a parallel strategy to use for pending trials or broken trials.
+        Default is a MaxParallelStrategy for broken trials and NoParallelStrategy for pending
+        trials.
+    convergence_duplicates: int, optional
+        Number of duplicate points the algorithm may sample before considering itself as done.
+        Default: 10.
 
     """
 
@@ -98,29 +106,43 @@ class BayesianOptimizer(BaseAlgorithm):
         self,
         space,
         seed=None,
-        strategy=None,
         n_initial_points=10,
         acq_func="gp_hedge",
         alpha=1e-10,
         n_restarts_optimizer=0,
         noise="gaussian",
         normalize_y=False,
+        parallel_strategy=None,
+        convergence_duplicates=5,
     ):
-        if strategy is not None:
-            log.warning("Strategy is deprecated and will be removed in v0.1.2.")
+        if parallel_strategy is None:
+            parallel_strategy = {
+                "of_type": "StatusBasedParallelStrategy",
+                "strategy_configs": {
+                    "broken": {
+                        "of_type": "MaxParallelStrategy",
+                    },
+                },
+                "default_strategy": {"of_type": "MaxParallelStrategy"},
+            }
 
-        self.optimizer = None
+        self.strategy = strategy_factory.create(**parallel_strategy)
+
+        self.rng = None
+        self._optimizer_state = {}
+        self._suggested = []
 
         super(BayesianOptimizer, self).__init__(
             space,
             seed=seed,
-            strategy=strategy,
             n_initial_points=n_initial_points,
             acq_func=acq_func,
             alpha=alpha,
             n_restarts_optimizer=n_restarts_optimizer,
             noise=noise,
             normalize_y=normalize_y,
+            parallel_strategy=parallel_strategy,
+            convergence_duplicates=convergence_duplicates,
         )
 
     @property
@@ -133,58 +155,55 @@ class BayesianOptimizer(BaseAlgorithm):
         """Set the space of the BO and initialize it"""
         self._original = self._space
         self._space = space
-        self._initialize()
 
-    def _initialize(self):
-        """Initialize the optimizer once the space is transformed"""
-        self.optimizer = Optimizer(
+    @contextlib.contextmanager
+    def get_optimizer(self):
+        optimizer = Optimizer(
             base_estimator=GaussianProcessRegressor(
                 alpha=self.alpha,
                 n_restarts_optimizer=self.n_restarts_optimizer,
                 noise=self.noise,
                 normalize_y=self.normalize_y,
+                random_state=self.rng.randint(0, np.iinfo(np.int32).max),
             ),
+            random_state=self.rng,
             dimensions=orion_space_to_skopt_space(self.space),
             n_initial_points=self.n_initial_points,
             acq_func=self.acq_func,
+            model_queue_size=1,
         )
+        if "gains_" in self._optimizer_state:
+            optimizer.gains_ = self._optimizer_state["gains_"]
+        points, results = self.get_data()
+        if points:
+            optimizer.tell(points, results)
 
-        self.seed_rng(self.seed)
+        yield optimizer
+
+        # We keep gains_ to rebuild the Optimizer based on copy() method here:
+        # https://github.com/scikit-optimize/scikit-optimize/blob/0.7.X/skopt/optimizer/optimizer.py#L272
+        if hasattr(optimizer, "gains_"):
+            self._optimizer_state["gains_"] = optimizer.gains_
 
     def seed_rng(self, seed):
         """Seed the state of the random number generator.
 
         :param seed: Integer seed for the random number generator.
         """
-        if self.optimizer:
-            self.optimizer.rng.seed(seed)
-            self.optimizer.base_estimator_.random_state = self.optimizer.rng.randint(
-                0, 100000
-            )
+        if self.rng is None:
+            self.rng = np.random.RandomState(seed)
+        else:
+            self.rng.seed(seed)
 
     @property
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
-        state_dict = super(BayesianOptimizer, self).state_dict
+        state_dict = copy.deepcopy(super(BayesianOptimizer, self).state_dict)
 
-        if self.optimizer is None:
-            return state_dict
-
-        state_dict.update(
-            {
-                "optimizer_rng_state": self.optimizer.rng.get_state(),
-                "estimator_rng_state": check_random_state(
-                    self.optimizer.base_estimator_.random_state
-                ).get_state(),
-                "Xi": self.optimizer.Xi,
-                "yi": self.optimizer.yi,
-                # pylint: disable = protected-access
-                "_n_initial_points": self.optimizer._n_initial_points,
-                "gains_": getattr(self.optimizer, "gains_", None),
-                "models": self.optimizer.models,
-                "_next_x": getattr(self.optimizer, "_next_x", None),
-            }
-        )
+        state_dict["rng_state"] = copy.deepcopy(self.rng.get_state())
+        state_dict["strategy"] = copy.deepcopy(self.strategy.state_dict)
+        state_dict["_suggested"] = copy.deepcopy(self._suggested)
+        state_dict["_optimizer_state"] = copy.deepcopy(self._optimizer_state)
 
         return state_dict
 
@@ -193,115 +212,63 @@ class BayesianOptimizer(BaseAlgorithm):
 
         :param state_dict: Dictionary representing state of an algorithm
         """
-        super(BayesianOptimizer, self).set_state(state_dict)
-        if self.optimizer and "optimizer_rng_state" in state_dict:
-            self.optimizer.rng.set_state(state_dict["optimizer_rng_state"])
-            rng = numpy.random.RandomState(0)
-            rng.set_state(state_dict["estimator_rng_state"])
-            self.optimizer.base_estimator_.random_state = rng
-            self.optimizer.Xi = state_dict["Xi"]
-            self.optimizer.yi = state_dict["yi"]
-            # pylint: disable = protected-access
-            self.optimizer._n_initial_points = state_dict["_n_initial_points"]
-            self.optimizer.gains_ = state_dict["gains_"]
-            self.optimizer.models = state_dict["models"]
-            # pylint: disable = protected-access
-            self.optimizer._next_x = state_dict["_next_x"]
+        super(BayesianOptimizer, self).set_state(copy.deepcopy(state_dict))
+
+        self.strategy.set_state(copy.deepcopy(state_dict["strategy"]))
+        self.rng.set_state(copy.deepcopy(state_dict["rng_state"]))
+        self._suggested = copy.deepcopy(state_dict["_suggested"])
+        self._optimizer_state = copy.deepcopy(state_dict["_optimizer_state"])
 
     def suggest(self, num=None):
-        """Suggest a `num`ber of new sets of parameters.
-
-        Perform a step towards negative gradient and suggest that point.
-
-        """
-        num = min(num, max(self.n_initial_points - self.n_suggested, 1))
-
+        """Suggest a `num`ber of new sets of parameters."""
         samples = []
-        candidates = []
-        while len(samples) < num:
-            if candidates:
-                candidate = candidates.pop(0)
-                if candidate:
-                    self.register(candidate)
-                    samples.append(candidate)
-            elif self.n_observed < self.n_initial_points:
-                candidates = self._suggest_random(num)
-            else:
-                candidates = self._suggest_bo(max(num - len(samples), 0))
+        with self.get_optimizer() as optimizer:
+            while len(samples) < num and not self.is_done:
+                new_point = optimizer.ask()
 
-            if not candidates:
-                break
+                self._suggested.append(new_point)
+                optimizer.tell(new_point, self.get_y(new_point))
+
+                trial = format_trials.tuple_to_trial(new_point, self.space)
+
+                if not self.has_suggested(trial):
+                    self.register(trial)
+                    samples.append(trial)
+
+        # if len(samples) < num:
+        #     log.warning(
+        #         "Bayesian optimizer could not sample %s in less than %s attemps. "
+        #         "Returning %s samples instead.",
+        #         num,
+        #         attempts,
+        #         len(samples),
+        #     )
 
         return samples
 
-    def _suggest(self, num, function):
-        points = []
+    def get_data(self):
+        X = copy.deepcopy(self._suggested)
+        y = []
+        for point in X:
+            y.append(self.get_y(point))
 
-        attempts = 0
-        max_attempts = 100
-        while len(points) < num and attempts < max_attempts:
-            for candidate in function(num - len(points)):
-                if not self.has_suggested(candidate):
-                    self.register(candidate)
-                    points.append(candidate)
+        return X, y
 
-                if self.is_done:
-                    return points
+    def get_y(self, point):
+        trial = format_trials.tuple_to_trial(point, self.space)
+        if self.has_observed(trial):
+            return self._trials_info[self.get_id(trial)][0].objective.value
 
-            attempts += 1
-            print(attempts)
+        return self.strategy.infer(trial).objective.value
 
-        return points
-
-    def _suggest_random(self, num):
-        def sample(num):
-            return self.space.sample(
-                num, seed=tuple(self.optimizer.rng.randint(0, 1000000, size=3))
-            )
-
-        return self._suggest(num, sample)
-
-    def _suggest_bo(self, num):
-        # pylint: disable = unused-argument
-        def suggest_bo(num):
-            # pylint: disable = protected-access
-            point = self.optimizer._ask()
-
-            # If already suggested, give corresponding result to BO to sample another point
-            if self.has_suggested(point):
-                result = self._trials_info[self.get_id(point)][1]
-                if result is None:
-                    results = []
-                    for _, other_result in self._trials_info.values():
-                        if other_result is not None:
-                            results.append(other_result["objective"])
-                    result = numpy.array(results).mean()
-                else:
-                    result = result["objective"]
-
-                self.optimizer.tell([point], [result])
-                return []
-
-            return [point]
-
-        return self._suggest(num, suggest_bo)
-
-    def observe(self, points, results):
+    def observe(self, trials):
         """Observe evaluation `results` corresponding to list of `points` in
         space.
 
-        Save current point and gradient corresponding to this point.
-
         """
-        to_tell = [[], []]
-        for point, result in zip(points, results):
-            if not self.has_observed(point):
-                self.register(point, result)
-                to_tell[0].append(point)
-                to_tell[1].append(result["objective"])
-
-        if to_tell[0]:
-            self.optimizer.tell(*to_tell)
+        self.strategy.observe(trials)
+        for trial in trials:
+            self.register(trial)
 
     @property
     def is_done(self):
@@ -311,6 +278,13 @@ class BayesianOptimizer(BaseAlgorithm):
         By default, the cardinality of the specified search space will be used to check
         if all possible sets of parameters has been tried.
         """
+        hits = defaultdict(int)
+        for point in self._suggested:
+            hits[self.get_id(format_trials.tuple_to_trial(point, self.space))] += 1
+
+        if hits and max(hits.values()) >= self.convergence_duplicates:
+            return True
+
         if self.n_suggested >= self._original.cardinality:
             return True
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -7,12 +7,14 @@ import os
 import numpy
 import orion.core.cli
 import pytest
+from orion.core.utils import backward, format_trials
 from orion.testing.algo import BaseAlgoTests
 
-N_INIT = 10
+N_INIT = 5
 
 
 class TestBOSkopt(BaseAlgoTests):
+    max_trials = 100
 
     algo_name = "bayesianoptimizer"
     config = {
@@ -22,45 +24,19 @@ class TestBOSkopt(BaseAlgoTests):
         "alpha": 1e-8,
         "n_restarts_optimizer": 0,
         "noise": False,
-        "strategy": None,
         "seed": 1234,  # Because this is so random
+        "convergence_duplicates": 5,
+        "parallel_strategy": {
+            "of_type": "StatusBasedParallelStrategy",
+            "strategy_configs": {
+                "broken": {"of_type": "MaxParallelStrategy", "default_result": 100},
+            },
+            "default_strategy": {
+                "of_type": "meanparallelstrategy",
+                "default_result": 50,
+            },
+        },
     }
-
-    def test_suggest_init(self, mocker):
-        algo = self.create_algo()
-        spy = self.spy_phase(mocker, 0, algo, "space.sample")
-        points = algo.suggest(1000)
-        assert len(points) == N_INIT
-
-    def test_suggest_init_missing(self, mocker):
-        algo = self.create_algo()
-        missing = 3
-        spy = self.spy_phase(mocker, N_INIT - missing, algo, "space.sample")
-        points = algo.suggest(1000)
-        assert len(points) == missing
-
-    def test_suggest_init_overflow(self, mocker):
-        algo = self.create_algo()
-        spy = self.spy_phase(mocker, N_INIT - 1, algo, "space.sample")
-        # Now reaching N_INIT
-        points = algo.suggest(1000)
-        assert len(points) == 1
-        # Verify point was sampled randomly, not using BO
-        assert spy.call_count == 1
-        # Overflow above N_INIT
-        points = algo.suggest(1000)
-        assert len(points) == 1
-        # Verify point was sampled randomly, not using BO
-        assert spy.call_count == 2
-
-    def test_suggest_n(self, mocker, num, attr):
-        algo = self.create_algo()
-        spy = self.spy_phase(mocker, num, algo, attr)
-        points = algo.suggest(5)
-        if num == 0:
-            assert len(points) == 5
-        else:
-            assert len(points) == 1
 
     def test_is_done_cardinality(self):
         # TODO: Support correctly loguniform(discrete=True)
@@ -78,9 +54,13 @@ class TestBOSkopt(BaseAlgoTests):
         algo = self.create_algo(space=space)
         for i, (x, y, z) in enumerate(itertools.product(range(5), "abc", range(1, 7))):
             assert not algo.is_done
-            n = len(algo.algorithm._trials_info)
-            algo.observe([[x, y, z]], [dict(objective=i)])
-            assert len(algo.algorithm._trials_info) == n + 1
+            n = algo.n_suggested
+            backward.algo_observe(
+                algo,
+                [format_trials.tuple_to_trial([x, y, z], space)],
+                [dict(objective=i)],
+            )
+            assert algo.n_suggested == n + 1
 
         assert i + 1 == space.cardinality
 
@@ -88,5 +68,5 @@ class TestBOSkopt(BaseAlgoTests):
 
 
 TestBOSkopt.set_phases(
-    [("random", 0, "space.sample"), ("bo", N_INIT + 1, "optimizer._ask")]
+    [("random", 0, "space.sample"), ("bo", N_INIT + 1, "space.sample")]
 )


### PR DESCRIPTION
The parallel strategy is now outside of Oríon's producer and must be
integrated inside the algorithms.

The initial points are now sampled from skopt's optimizer
to simplify the implementation and stay as close as possible to skopt.
Whenever a point sampled is equivalent to one already sampled, it is
added to a list of points sampled by the optimizer but not returned as a
suggested trial. The optimizer is recreated every time suggest is called
and saved points are used to set back its state. This is done to avoid
passing the same points to optimizer.tell multiple times if they are not
completed. The non completed points are assigned fake results using the
parallel strategy and passed to optimizer.tell(), but doing so multiple
times (which happens if the trials are not completed during multiple
calls to suggest()) will lead to having the GP model fitting the same
point multiple time with different results.
